### PR TITLE
[W-18452741] Fix Rust version typo on support.1.4.x (cherry-pick)

### DIFF
--- a/ai-prompt-decorator/Cargo.toml
+++ b/ai-prompt-decorator/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "ai_prompt_decorator"
 version = "1.0.0"
-rust-version = "1.83..0"
+rust-version = "1.83.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "block"
 version = "1.0.0"
-rust-version = "1.83..0"
+rust-version = "1.83.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/certs/Cargo.toml
+++ b/certs/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "certs"
 version = "1.0.1"
-rust-version = "1.83..0"
+rust-version = "1.83.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/cors-validation/Cargo.toml
+++ b/cors-validation/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "cors_validation"
 version = "1.0.0"
-rust-version = "1.83..0"
+rust-version = "1.83.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "crypto"
 version = "1.0.1"
-rust-version = "1.83..0"
+rust-version = "1.83.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/data-caching/Cargo.toml
+++ b/data-caching/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "data_caching"
 version = "1.0.1"
-rust-version = "1.83..0"
+rust-version = "1.83.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/jwt-validation/Cargo.toml
+++ b/jwt-validation/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "jwt_validation"
 version = "1.0.1"
-rust-version = "1.83..0"
+rust-version = "1.83.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "metrics"
 version = "1.0.0"
-rust-version = "1.83..0"
+rust-version = "1.83.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "query"
 version = "1.0.1"
-rust-version = "1.83..0"
+rust-version = "1.83.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/simple-oauth-2-validation-grpc/Cargo.toml
+++ b/simple-oauth-2-validation-grpc/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "simple_oauth_2_validation_grpc"
 version = "1.0.1"
-rust-version = "1.83..0"
+rust-version = "1.83.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/simple-oauth-2-validation/Cargo.toml
+++ b/simple-oauth-2-validation/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "simple_oauth_2_validation"
 version = "1.0.1"
-rust-version = "1.83..0"
+rust-version = "1.83.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/spike/Cargo.toml
+++ b/spike/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "spike"
 version = "1.0.0"
-rust-version = "1.83..0"
+rust-version = "1.83.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tls-calls/Cargo.toml
+++ b/tls-calls/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "tls_calls"
 version = "1.0.0"
-rust-version = "1.83..0"
+rust-version = "1.83.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Rust version had a typo which was fixed already at `main`, bringing fix to `support/1.4.x`.