### PR TITLE
W-18697356: Update flex version to 1.10.0 (cherry-pick) (#88)

### DIFF
--- a/ai-basic-token-rate-limiting/playground/docker-compose.yaml
+++ b/ai-basic-token-rate-limiting/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/ai-basic-token-rate-limiting/tests/requests.rs
+++ b/ai-basic-token-rate-limiting/tests/requests.rs
@@ -44,7 +44,7 @@ async fn rate_limit() -> anyhow::Result<()> {
 
     // Configure a Flex service
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "config")])

--- a/ai-prompt-decorator/playground/docker-compose.yaml
+++ b/ai-prompt-decorator/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/ai-prompt-decorator/tests/requests.rs
+++ b/ai-prompt-decorator/tests/requests.rs
@@ -60,7 +60,7 @@ async fn chat() -> anyhow::Result<()> {
 
     // Configure a Flex service
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/ai-prompt-guard/playground/docker-compose.yaml
+++ b/ai-prompt-guard/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/ai-prompt-guard/tests/requests.rs
+++ b/ai-prompt-guard/tests/requests.rs
@@ -56,7 +56,7 @@ async fn chat() -> anyhow::Result<()> {
 
     // Configure a Flex service
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/ai-prompt-template/playground/docker-compose.yaml
+++ b/ai-prompt-template/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/ai-prompt-template/tests/requests.rs
+++ b/ai-prompt-template/tests/requests.rs
@@ -69,7 +69,7 @@ async fn chat() -> anyhow::Result<()> {
 
     // Configure a Flex service
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/block/playground/docker-compose.yaml
+++ b/block/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/block/tests/requests.rs
+++ b/block/tests/requests.rs
@@ -40,7 +40,7 @@ async fn block() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/certs/playground/docker-compose.yaml
+++ b/certs/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/certs/tests/requests.rs
+++ b/certs/tests/requests.rs
@@ -35,7 +35,7 @@ async fn certs() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/cors-validation/playground/docker-compose.yaml
+++ b/cors-validation/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/cors-validation/tests/common/mod.rs
+++ b/cors-validation/tests/common/mod.rs
@@ -42,7 +42,7 @@ pub async fn compose<T: Serialize>(config: &T) -> Result<TestComposite> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .with_api(api)
         .config_mounts([
             (COMMON_CONFIG_DIR, "common"),

--- a/crypto/playground/docker-compose.yaml
+++ b/crypto/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/crypto/tests/requests.rs
+++ b/crypto/tests/requests.rs
@@ -90,7 +90,7 @@ async fn crypto() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/data-caching/playground/docker-compose.yaml
+++ b/data-caching/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/data-caching/tests/requests.rs
+++ b/data-caching/tests/requests.rs
@@ -43,7 +43,7 @@ async fn caching() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/data-storage-stats/playground/docker-compose.yaml
+++ b/data-storage-stats/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/data-storage-stats/tests/requests.rs
+++ b/data-storage-stats/tests/requests.rs
@@ -41,7 +41,7 @@ async fn test_basic_local_storage_functionality() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex-basic")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -132,7 +132,7 @@ async fn test_admin_stats_operations() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex-admin")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -234,7 +234,7 @@ async fn test_cas_concurrency_handling() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex-cas")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -324,7 +324,7 @@ async fn test_multiple_clients_concurrent_access() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex-concurrent")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -430,7 +430,7 @@ async fn test_remote_storage_functionality() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex-remote")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -516,7 +516,7 @@ async fn test_invalid_configuration_handling() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex-invalid")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/jwt-validation/playground/docker-compose.yaml
+++ b/jwt-validation/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/jwt-validation/tests/requests.rs
+++ b/jwt-validation/tests/requests.rs
@@ -38,7 +38,7 @@ async fn validate_token() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/metrics/playground/docker-compose.yaml
+++ b/metrics/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/metrics/tests/requests.rs
+++ b/metrics/tests/requests.rs
@@ -43,7 +43,7 @@ async fn metrics() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/multi-instance-rate-limiting/playground/docker-compose.yaml
+++ b/multi-instance-rate-limiting/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex-1:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:
@@ -14,7 +14,7 @@ services:
       - FLEX_INSTANCE_ID=flex-1
 
   local-flex-2:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8082:8081
     volumes:

--- a/multi-instance-rate-limiting/tests/requests.rs
+++ b/multi-instance-rate-limiting/tests/requests.rs
@@ -46,7 +46,7 @@ async fn test_basic_rate_limiting_with_api_key() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex-api-key")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -144,7 +144,7 @@ async fn test_rate_limiting_with_user_id() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex-user-id")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -246,7 +246,7 @@ async fn test_single_request_limit() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex-single")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -332,7 +332,7 @@ async fn test_different_window_sizes() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex-window")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -435,7 +435,7 @@ async fn test_api_key_rate_limiting() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex-multi-limits")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/query/playground/docker-compose.yaml
+++ b/query/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/query/tests/requests.rs
+++ b/query/tests/requests.rs
@@ -38,7 +38,7 @@ async fn query() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -79,10 +79,9 @@ async fn query() -> anyhow::Result<()> {
             when.header("X-Query-Key", "value")
                 .header("X-Query-Missing", "Undefined")
                 .header("X-Query-Extra", "")
-                .header(
-                    "X-Envoy-Original-Path",
-                    "/hello?absent=absent&removed=extra&removed=key",
-                );
+                .query_param("absent", "absent")
+                .query_param("removed", "extra")
+                .query_param("removed", "key");
             then.status(200);
         })
         .await;

--- a/simple-oauth-2-validation-grpc/playground/docker-compose.yaml
+++ b/simple-oauth-2-validation-grpc/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/simple-oauth-2-validation-grpc/tests/requests.rs
+++ b/simple-oauth-2-validation-grpc/tests/requests.rs
@@ -57,7 +57,7 @@ async fn accept_token() -> anyhow::Result<()> {
 
     // Configure Flex Gateway
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/simple-oauth-2-validation/playground/docker-compose.yaml
+++ b/simple-oauth-2-validation/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/simple-oauth-2-validation/tests/requests.rs
+++ b/simple-oauth-2-validation/tests/requests.rs
@@ -155,7 +155,7 @@ fn flex_config(upstream_config: &HttpMockConfig, policy_config: PolicyConfig) ->
         .build();
 
     FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/spike/playground/docker-compose.yaml
+++ b/spike/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/spike/tests/requests.rs
+++ b/spike/tests/requests.rs
@@ -49,7 +49,7 @@ async fn spike() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/stream-payload/playground/docker-compose.yaml
+++ b/stream-payload/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/stream-payload/tests/requests.rs
+++ b/stream-payload/tests/requests.rs
@@ -42,7 +42,7 @@ async fn reject_forbidden() -> anyhow::Result<()> {
 
     // Configure a Flex service
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/tls-calls/playground/docker-compose.yaml
+++ b/tls-calls/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:


### PR DESCRIPTION
Flex version was recently updated from `1.7.0` to `1.10.0` in `main`, now we need to bring this update to `support/1.5.x` and also update the version in new examples (which only live in `support/1.5.x`).