### PR TITLE
@W-23346650 Add Flex min version metadata to Cargo.toml files

### DIFF
--- a/.scripts/README.md
+++ b/.scripts/README.md
@@ -11,3 +11,16 @@ Builds all policy examples:
 
 Runs the tests of all policy examples:
 `./.scripts/test.sh <pathToRegistrationFile>`
+
+Set `PDK_TEST_FLEX_IMAGE_VERSION` (and optionally `PDK_TEST_FLEX_IMAGE_NAME`) to the
+Flex version under test. An example that declares a higher minimum Flex version is
+skipped, so any job that runs these tests inherits the same Flex-compatibility rules:
+`PDK_TEST_FLEX_IMAGE_VERSION=1.11.0 ./.scripts/test.sh <pathToRegistrationFile>`
+
+An example declares its minimum in `Cargo.toml`; examples without a declaration have
+no minimum and always run:
+
+```toml
+[package.metadata.flex]
+min-version = "1.12.0"
+```

--- a/.scripts/test.sh
+++ b/.scripts/test.sh
@@ -1,15 +1,161 @@
+#!/bin/bash
+# Copyright 2023 Salesforce, Inc. All rights reserved.
+#
+# Single entry point to run the integration tests of every policy example.
+#
+# Usage:
+#   ./.scripts/test.sh <path-to-registration.yaml>
+#
+# Environment:
+#   PDK_TEST_FLEX_IMAGE_VERSION  Flex version under test (e.g. 1.9.3000). Used to
+#                                skip examples that declare a higher minimum Flex
+#                                version. Also consumed by pdk-test to select the
+#                                Flex image. When unset or "latest", no example is
+#                                skipped.
+#
+# An example declares its minimum Flex version in Cargo.toml:
+#
+#   [package.metadata.flex]
+#   min-version = "1.12.0"
+#
+# Examples requiring a version newer than PDK_TEST_FLEX_IMAGE_VERSION are skipped,
+# so any job running these tests inherits the same compatibility rules. Examples
+# without a declaration have no minimum and always run.
+
 if [ -z "$1" ]; then
     echo "No path to registration file was given";
+    echo "Usage: $0 <path-to-registration.yaml>";
     exit 1;
 fi
 
-for f in *; do
-    if [ -d "$f" ]; then
-        echo "Testing '$f' policy example";
-        cd "$f";
-        cp $1 ./tests/common/registration.yaml
-        make setup && make test;
-        rm ./tests/common/registration.yaml
-        cd ..;
+REGISTRATION_FILE="$1"
+
+if [ ! -f "$REGISTRATION_FILE" ]; then
+    echo "Error: registration file not found: $REGISTRATION_FILE";
+    exit 1;
+fi
+
+FLEX_VERSION="${PDK_TEST_FLEX_IMAGE_VERSION:-}"
+
+# Returns 0 (true) when $1 < $2 numerically, comparing dot-separated components.
+# Missing components default to 0, so "1.12" == "1.12.0".
+version_lt() {
+    local v1="$1" v2="$2" i
+    local -a p1 p2
+    IFS='.' read -r -a p1 <<< "$v1"
+    IFS='.' read -r -a p2 <<< "$v2"
+    local max="${#p1[@]}"
+    [ "${#p2[@]}" -gt "$max" ] && max="${#p2[@]}"
+    for ((i = 0; i < max; i++)); do
+        local a="${p1[i]:-0}" b="${p2[i]:-0}"
+        # Non-numeric component (e.g. a suffix) => treat as equal, stop comparing.
+        [[ "$a" =~ ^[0-9]+$ ]] || return 1
+        [[ "$b" =~ ^[0-9]+$ ]] || return 1
+        if [ "$a" -lt "$b" ]; then return 0; fi
+        if [ "$a" -gt "$b" ]; then return 1; fi
+    done
+    return 1
+}
+
+# Prints the min-version declared under [package.metadata.flex] in the
+# example's Cargo.toml, or nothing when absent. Uses awk (jq is not available in
+# CI) and requires no build.
+min_flex_version() {
+    local cargo="${1}Cargo.toml"
+    [ -f "$cargo" ] || return 0
+    awk '
+        /^\[package\.metadata\.flex\]/ { in_section = 1; next }
+        /^\[/                          { in_section = 0 }
+        in_section && /^[[:space:]]*min-version[[:space:]]*=/ {
+            gsub(/^[^"]*"/, ""); gsub(/".*$/, ""); print; exit
+        }
+    ' "$cargo"
+}
+
+# Returns 0 (true) when the example in $1 must be skipped for FLEX_VERSION.
+should_skip() {
+    local dir="$1"
+    # Unknown / rolling versions run everything.
+    [ -z "$FLEX_VERSION" ] && return 1
+    [ "$FLEX_VERSION" = "latest" ] && return 1
+    local min
+    min="$(min_flex_version "$dir")"
+    # No declaration => no minimum => always run.
+    [ -z "$min" ] && return 1
+    version_lt "$FLEX_VERSION" "$min"
+}
+
+echo "PDK Custom Policy Examples tests starting..."
+echo "Flex version under test: ${FLEX_VERSION:-<unset>}"
+
+total=0
+success=0
+failed=0
+skipped=0
+
+set +e
+
+for dir in */; do
+    if [ -f "${dir}Makefile" ] && [ -f "${dir}Cargo.toml" ]; then
+        dir_name="${dir%/}"
+
+        if should_skip "$dir"; then
+            skipped=$((skipped + 1))
+            echo ""
+            echo "Skipping ${dir_name} (requires Flex >= $(min_flex_version "$dir"), testing ${FLEX_VERSION})"
+            continue
+        fi
+
+        total=$((total + 1))
+
+        echo ""
+        echo "Testing ${dir_name}..."
+
+        cd "$dir" || { failed=$((failed + 1)); continue; }
+
+        # Provide the registration file wherever the example expects it.
+        if [ -d "tests/config" ]; then
+            cp "$REGISTRATION_FILE" tests/config/registration.yaml
+        elif [ -d "tests/common" ]; then
+            cp "$REGISTRATION_FILE" tests/common/registration.yaml
+        fi
+
+        make setup && make build
+
+        accum=0
+        tests=$(cargo test -- --list 2>/dev/null | grep ": test" | sed 's|\(.*\): test|\1|g')
+        for single_test in $tests; do
+            echo "Running test '$single_test'";
+            cargo test "$single_test" -- --nocapture;
+            accum=$((accum + $?))
+        done
+
+        if [ $accum -eq 0 ]; then
+            success=$((success + 1))
+            echo "PASSED: ${dir_name}"
+        else
+            failed=$((failed + 1))
+            echo "FAILED: ${dir_name}"
+
+            echo ""
+            echo "==================== Flex Logs for ${dir_name} ===================="
+            for log_file in $(find target/pdk-test -name "local-flex.log" 2>/dev/null); do
+                echo "--- ${log_file} ---"
+                cat "${log_file}" 2>/dev/null || echo "(empty or not found)"
+                echo ""
+            done
+            echo "=================================================================="
+        fi
+
+        cd .. || exit 1
     fi
 done
+
+echo ""
+echo "============================== Examples Test Summary =============================="
+echo "Total: $total | Success: $success | Failed: $failed | Skipped: $skipped"
+
+if [ $failed -gt 0 ]; then
+    echo "ERROR: $failed examples failed"
+    exit 1
+fi

--- a/.scripts/test.sh
+++ b/.scripts/test.sh
@@ -7,11 +7,7 @@
 #   ./.scripts/test.sh <path-to-registration.yaml>
 #
 # Environment:
-#   PDK_TEST_FLEX_IMAGE_VERSION  Flex version under test (e.g. 1.9.3000). Used to
-#                                skip examples that declare a higher minimum Flex
-#                                version. Also consumed by pdk-test to select the
-#                                Flex image. When unset or "latest", no example is
-#                                skipped.
+#   PDK_TEST_FLEX_IMAGE_VERSION  Flex version under test (e.g. 1.9.3000).
 #
 # An example declares its minimum Flex version in Cargo.toml:
 #
@@ -58,8 +54,7 @@ version_lt() {
 }
 
 # Prints the min-version declared under [package.metadata.flex] in the
-# example's Cargo.toml, or nothing when absent. Uses awk (jq is not available in
-# CI) and requires no build.
+# example's Cargo.toml, or nothing when absent.
 min_flex_version() {
     local cargo="${1}Cargo.toml"
     [ -f "$cargo" ] || return 0

--- a/ai-basic-token-rate-limiting/tests/requests.rs
+++ b/ai-basic-token-rate-limiting/tests/requests.rs
@@ -44,7 +44,6 @@ async fn rate_limit() -> anyhow::Result<()> {
 
     // Configure a Flex service
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "config")])

--- a/ai-prompt-decorator/tests/requests.rs
+++ b/ai-prompt-decorator/tests/requests.rs
@@ -60,7 +60,6 @@ async fn chat() -> anyhow::Result<()> {
 
     // Configure a Flex service
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/ai-prompt-guard/tests/requests.rs
+++ b/ai-prompt-guard/tests/requests.rs
@@ -56,7 +56,6 @@ async fn chat() -> anyhow::Result<()> {
 
     // Configure a Flex service
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/ai-prompt-template/tests/requests.rs
+++ b/ai-prompt-template/tests/requests.rs
@@ -69,7 +69,6 @@ async fn chat() -> anyhow::Result<()> {
 
     // Configure a Flex service
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/block/tests/requests.rs
+++ b/block/tests/requests.rs
@@ -40,7 +40,6 @@ async fn block() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/certs/tests/requests.rs
+++ b/certs/tests/requests.rs
@@ -35,7 +35,6 @@ async fn certs() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/cors-validation/tests/common/mod.rs
+++ b/cors-validation/tests/common/mod.rs
@@ -41,7 +41,6 @@ pub async fn compose<T: Serialize>(config: &T) -> Result<TestComposite> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .with_api(api)
         .config_mounts([
             (COMMON_CONFIG_DIR, "common"),

--- a/crypto/tests/requests.rs
+++ b/crypto/tests/requests.rs
@@ -90,7 +90,6 @@ async fn crypto() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/data-caching/tests/requests.rs
+++ b/data-caching/tests/requests.rs
@@ -43,7 +43,6 @@ async fn caching() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/data-storage-stats/tests/requests.rs
+++ b/data-storage-stats/tests/requests.rs
@@ -41,7 +41,6 @@ async fn test_basic_local_storage_functionality() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-basic")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -132,7 +131,6 @@ async fn test_admin_stats_operations() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-admin")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -234,7 +232,6 @@ async fn test_cas_concurrency_handling() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-cas")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -324,7 +321,6 @@ async fn test_multiple_clients_concurrent_access() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-concurrent")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -431,7 +427,6 @@ async fn test_invalid_configuration_handling() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-invalid")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -495,7 +490,6 @@ async fn test_remote_storage_with_multiple_clients() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-remote")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/dataweave/Cargo.toml
+++ b/dataweave/Cargo.toml
@@ -13,6 +13,9 @@ group_id = "f7a576be-e707-4ce3-9c68-3432d591846c"
 definition_asset_id = "dataweave"
 implementation_asset_id = "dataweave-flex"
 
+[package.metadata.flex]
+min-version = "1.11.0"
+
 [dependencies]
 pdk = { version = "1.9.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/dataweave/tests/requests.rs
+++ b/dataweave/tests/requests.rs
@@ -42,7 +42,6 @@ async fn dataweave() -> anyhow::Result<()> {
 
     // Configure a Flex service
     let flex_config = FlexConfig::builder()
-        .version("1.11.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/ip-filter/tests/requests.rs
+++ b/ip-filter/tests/requests.rs
@@ -39,7 +39,6 @@ async fn test_allowlist_ip_passes() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -112,7 +111,6 @@ async fn test_allowlist_blocks_non_allowed_ip() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-forbidden")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -184,7 +182,6 @@ async fn test_blocklist_blocks_ip() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-blocklist")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -256,7 +253,6 @@ async fn test_blocklist_allows_non_blocked_ip() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-blocklist-pass")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -328,7 +324,6 @@ async fn test_blocklist_cidr_range_blocks_ip() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-blocklist-cidr")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/jwt-generation/tests/requests.rs
+++ b/jwt-generation/tests/requests.rs
@@ -108,7 +108,6 @@ async fn jwt() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/jwt-validation/tests/requests.rs
+++ b/jwt-validation/tests/requests.rs
@@ -38,7 +38,6 @@ async fn validate_token() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/metrics/tests/requests.rs
+++ b/metrics/tests/requests.rs
@@ -43,7 +43,6 @@ async fn metrics() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/multi-instance-rate-limiting/tests/requests.rs
+++ b/multi-instance-rate-limiting/tests/requests.rs
@@ -46,7 +46,6 @@ async fn test_basic_rate_limiting_with_api_key() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-api-key")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -144,7 +143,6 @@ async fn test_rate_limiting_with_user_id() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-user-id")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -246,7 +244,6 @@ async fn test_single_request_limit() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-single")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -332,7 +329,6 @@ async fn test_different_window_sizes() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-window")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])
@@ -435,7 +431,6 @@ async fn test_api_key_rate_limiting() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex-multi-limits")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/oauth-2-token-introspection/tests/requests.rs
+++ b/oauth-2-token-introspection/tests/requests.rs
@@ -241,7 +241,6 @@ fn flex_config(upstream_config: &HttpMockConfig, policy_config: PolicyConfig) ->
         .build();
 
     FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/query/tests/requests.rs
+++ b/query/tests/requests.rs
@@ -38,7 +38,6 @@ async fn query() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/simple-oauth-2-validation-grpc/tests/requests.rs
+++ b/simple-oauth-2-validation-grpc/tests/requests.rs
@@ -57,7 +57,6 @@ async fn accept_token() -> anyhow::Result<()> {
 
     // Configure Flex Gateway
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/simple-oauth-2-validation/tests/requests.rs
+++ b/simple-oauth-2-validation/tests/requests.rs
@@ -155,7 +155,6 @@ fn flex_config(upstream_config: &HttpMockConfig, policy_config: PolicyConfig) ->
         .build();
 
     FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/spike/tests/requests.rs
+++ b/spike/tests/requests.rs
@@ -49,7 +49,6 @@ async fn spike() -> anyhow::Result<()> {
         .build();
 
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/stop-iteration/Cargo.toml
+++ b/stop-iteration/Cargo.toml
@@ -13,6 +13,9 @@ group_id = "007e256a-fd7e-4fe2-bb1d-78c22cd0d3ca"
 definition_asset_id = "stop-iteration"
 implementation_asset_id = "stop-iteration-flex"
 
+[package.metadata.flex]
+min-version = "1.12.0"
+
 [dependencies]
 pdk = { version = "1.9.0", features = ["enable_stop_iteration"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/stop-iteration/tests/requests.rs
+++ b/stop-iteration/tests/requests.rs
@@ -45,7 +45,6 @@ async fn test_stop_iteration_modifies_response() -> anyhow::Result<()> {
 
     // Configure Flex service
     let flex_config = FlexConfig::builder()
-        .version("1.12.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])

--- a/stream-payload/tests/requests.rs
+++ b/stream-payload/tests/requests.rs
@@ -42,7 +42,6 @@ async fn reject_forbidden() -> anyhow::Result<()> {
 
     // Configure a Flex service
     let flex_config = FlexConfig::builder()
-        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([(POLICY_DIR, "policy"), (COMMON_CONFIG_DIR, "common")])


### PR DESCRIPTION
- Add `[package.metadata.flex] min-version` to `Cargo.toml` so `scripts/test.sh` skips examples whose minimum is newer than `PDK_TEST_FLEX_IMAGE_VERSION`
- Remove hardcoded FlexConfig `.version()` pins so examples inherit the env var